### PR TITLE
add register-app view

### DIFF
--- a/src/routers/authRouter.js
+++ b/src/routers/authRouter.js
@@ -7,6 +7,11 @@ router.route('/login')
     res.render('login')
   })
 
+router.route('/oauth/register-app')
+  .get((req, res) => res.render('oauth/register-app'))
+  // TODO
+  .post((req, res) => res.send('TODO'))
+
 router.route('/oauth/authorize')
   .get(oauthController.getAuthorizePage)
   .post(oauthController.getAuthorizationCode)

--- a/src/views/oauth/register-app.handlebars
+++ b/src/views/oauth/register-app.handlebars
@@ -1,0 +1,21 @@
+<form class="{{> classes/form }}" method="POST" action="/oauth/register-app">
+
+  <h2 class="{{> classes/formTitle }}">Register an app</h2>
+
+  <span>(required fields are signalled with a *)</span>
+
+  <label class="{{> classes/formLabel }}">App Name:*
+    <input class="{{> classes/formInput }}" type="text" name="name" required>
+  </label>
+
+  <label class="{{> classes/formLabel }}">Redirect URI option 1:*
+    <input class="{{> classes/formInput }}" type="text" name="redirectUri" required>
+  </label>
+
+  <label class="{{> classes/formLabel }}">Redirect URI option 2:
+    <input class="{{> classes/formInput }}" type="text" name="redirectUri_2">
+  </label>
+
+  <button class="{{> classes/formSubmit }}" type="submit" value="submit">Submit</button>
+
+</form>

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -14,3 +14,15 @@ tape('test /login route', t => {
       t.end()
     })
 })
+
+tape('GET /oauth/register-app route', t => {
+  supertest(server)
+    .get('/oauth/register-app')
+    .expect(200)
+    .expect('Content-Type', /html/)
+    .end((err, res) => {
+      if (err) t.fail(err)
+      t.ok(res.text.includes('Register an app'), 'should return page including "Register an app"')
+      t.end()
+    })
+})


### PR DESCRIPTION
relates #104 

"as a user, I want to be able to go to a page to register an app to use OAuth with the OTP"

**assigned low priority as for now, we can manually enter the data entry and events apps into the db**

fields:
- name
- redirectUri
- redirectUri2