### PR TITLE
add name field to client model

### DIFF
--- a/src/models/auth/Client.js
+++ b/src/models/auth/Client.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose')
 
 const clientSchema = mongoose.Schema(
   {
+    name: { type: String, required: true },
     user: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
     secret: String,
     grants: [ String ],

--- a/tests/fixtures/auth/clients.json
+++ b/tests/fixtures/auth/clients.json
@@ -1,6 +1,7 @@
 {
 	"client": {
 		"_id": "507f1f77bcf86cd799439011",
+		"name": "the client",
 		"user": "5986abad5e2d852cb1ee6bce",
 		"secret": "secret",
 		"grants": [ "authorization_code" ],


### PR DESCRIPTION
related #111 

**add name field to client model** (client is an app in the OAuth flow)

apps need names otherwise the only identifier is the user (owner) and the redirect URIs