### PR TITLE
Finalise api v1

### DIFF
--- a/data_spec_v1.md
+++ b/data_spec_v1.md
@@ -82,7 +82,7 @@ name | type | required | permissions
 id | KEY | true |-
 createdAt| DATE | - | -
 updatedAt| DATE | - | -
-ownerId | FOREIGN KEY | false | ADMIN
+owner | FOREIGN KEY | false | ADMIN
 isVerified | BOOL | true | ADMIN
 name| STRING | | OWNER
 address | ADDRESS | true | OWNER
@@ -116,7 +116,7 @@ name | type | required | permissions
 id | KEY | true |-
 createdAt| DATE | - | -
 updatedAt| DATE | - | -
-ownerId | FOREIGN KEY | false | ADMIN
+owner | FOREIGN KEY | false | ADMIN
 name| STRING | | OWNER
 location| LOCATION | | OWNER
 category|  | OWNER
@@ -147,7 +147,7 @@ name | type | required | scope
 id | KEY | true |-
 createdAt| DATE | - | -
 updatedAt| DATE | - | -
-ownerId | FOREIGN KEY | false | ADMIN
+owner | FOREIGN KEY | false | ADMIN
 name| STRING | | OWNER
 category| ENUM | | OWNER
 description| TEXT | | OWNER

--- a/docs.md
+++ b/docs.md
@@ -55,7 +55,7 @@ Status: 200 OK
     "updatedAt": "2017-08-02T14:48:20.989Z",
     "createdAt": "2017-08-02T14:48:20.989Z",
     "ownerId": "8496873ea34958810182138c",
-    "placeId": {
+    "place": {
       _id: '599152711fd6dc190c9940c1',
       "updatedAt": "2017-08-14T07:34:09.985Z",
       "createdAt": "2017-08-14T07:34:09.985Z",
@@ -100,7 +100,7 @@ Status: 200 OK
   "updatedAt": "2017-08-02T14:48:20.989Z",
   "createdAt": "2017-08-02T14:48:20.989Z",
   "ownerId": "8496873ea34958810182138c",
-  "placeId": "placeId": {
+  "place": "place": {
     _id: '599152711fd6dc190c9940c1',
     "updatedAt": "2017-08-14T07:34:09.985Z",
     "createdAt": "2017-08-14T07:34:09.985Z",
@@ -141,7 +141,7 @@ Name | Type | Description
 ---|---|---
 ownerId | mongoose ObjectId | id of event owner.
 categories | array of strings | **Required**. Event [categories](https://github.com/foundersandcoders/open-tourism-platform/blob/master/src/models/constants.json).
-placeId | mongoose ObjectId | id of event location.
+place | mongoose ObjectId | id of event location.
 accessibilityOptions | array of strings | Event [accessibility options](https://github.com/foundersandcoders/open-tourism-platform/blob/master/src/models/constants.json).
 startTime | date | Event start time.
 endTime | date | Event end time.
@@ -160,7 +160,7 @@ description* | string | More information about event.
     "music",
     "dining"
   ],
-  "placeId": "9348293df12398123885930a",
+  "place": "9348293df12398123885930a",
   "accessibilityOptions": [
     "braille-menu",
     "wheelchair-friendly"
@@ -185,7 +185,7 @@ Status: 201 Created
   "updatedAt": "2017-08-02T14:48:20.989Z",
   "createdAt": "2017-08-02T14:48:20.989Z",
   "ownerId": "8496873ea34958810182138c",
-  "placeId": "9348293df12398123885930a",
+  "place": "9348293df12398123885930a",
   "startTime": "2001-01-01T00:00:00.000Z",
   "endTime": "2002-02-02T00:00:00.000Z",
   "cost": "100 shekels",
@@ -215,7 +215,7 @@ Name | Type | Description
 ---|---|---
 ownerId | mongoose ObjectId | id of event owner.
 categories | array of strings | **Required**. Event [categories](https://github.com/foundersandcoders/open-tourism-platform/blob/master/src/models/constants.json).
-placeId | mongoose ObjectId | id of event location.
+place | mongoose ObjectId | id of event location.
 accessibilityOptions | array of strings | Event [accessibility options](https://github.com/foundersandcoders/open-tourism-platform/blob/master/src/models/constants.json).
 startTime | date | Event start time.
 endTime | date | Event end time.
@@ -244,7 +244,7 @@ Status: 200 OK
   "updatedAt": "2017-08-02T14:48:20.989Z",
   "createdAt": "2017-08-02T14:48:20.989Z",
   "ownerId": "8496873ea34958810182138c",
-  "placeId": "9348293df12398123885930a",
+  "place": "9348293df12398123885930a",
   "startTime": "2001-01-01T00:00:00.000Z",
   "endTime": "2002-02-02T00:00:00.000Z",
   "cost": "100 shekels",

--- a/docs.md
+++ b/docs.md
@@ -33,6 +33,11 @@ Base URL: https://nazareth-open-tourism-platform.herokuapp.com/
 - [Update user](#update-user)
 - [Delete user](#delete-user)
 
+**Categories**
+- [Accessibility Options](#accessibility-options)
+- [Places](#place-categories)
+- [Event](#event-categories)
+- [Producs](#product-categories)
 ## Events
 
 ### Get all events
@@ -77,8 +82,8 @@ Status: 200 OK
     },
     "_id": "5981e634b6e958614d64e111",
     "accessibilityOptions": [
-      "braille-menu",
-      "wheelchair-friendly"
+      "Braille",
+      "Wheelchair access"
     ],
     "categories": [
       "music",
@@ -122,8 +127,8 @@ Status: 200 OK
   },
   "_id": "5981e634b6e958614d64e111",
   "accessibilityOptions": [
-    "braille-menu",
-    "wheelchair-friendly"
+    "Braille",
+    "Wheelchair access"
   ],
   "categories": [
     "music",
@@ -162,8 +167,8 @@ description* | string | More information about event.
   ],
   "place": "9348293df12398123885930a",
   "accessibilityOptions": [
-    "braille-menu",
-    "wheelchair-friendly"
+    "Braille",
+    "Wheelchair access"
   ],
   "startTime": "2001-01-01T00:00:00.000Z",
   "endTime": "2002-02-02T00:00:00.000Z",
@@ -196,8 +201,8 @@ Status: 201 Created
   },
   "_id": "5981e634b6e958614d64e111",
   "accessibilityOptions": [
-    "braille-menu",
-    "wheelchair-friendly"
+    "Braille",
+    "Wheelchair access"
   ],
   "categories": [
     "music",
@@ -255,8 +260,8 @@ Status: 200 OK
   },
   "_id": "5981e634b6e958614d64e111",
   "accessibilityOptions": [
-    "braille-menu",
-    "wheelchair-friendly"
+    "Braille",
+    "Wheelchair access"
   ],
   "categories": [
     "music",
@@ -305,11 +310,11 @@ Status: 200 OK
     },
     "_id": "597eeb64aecdd6283a873898",
     "accessibilityOptions": [
-      "braille-menu",
-      "wheelchair-friendly"
+      "Braille",
+      "Wheelchair access"
     ],
     "categories": [
-      "restaurant",
+      "food and drink",
       "cafe"
     ]
   }
@@ -344,11 +349,11 @@ Status: 200 OK
   },
   "_id": "597eeb64aecdd6283a873898",
   "accessibilityOptions": [
-    "braille-menu",
-    "wheelchair-friendly"
+    "Braille",
+    "Wheelchair access"
   ],
   "categories": [
-    "restaurant",
+    "food and drink",
     "cafe"
   ]
 }
@@ -385,12 +390,12 @@ openingHours* | string | Place opening hours.
     32.2968133
   ],
   "categories": [
-    "restaurant",
+    "food and drink",
     "cafe"
   ],
   "accessibilityOptions": [
-    "braille-menu",
-    "wheelchair-friendly"
+    "Braille",
+    "Wheelchair access"
   ],
   "imageUrl": "imgIsHere.com/12345",
   "website": "myWebsite.com",
@@ -430,11 +435,11 @@ Status: 201 Created
   },
   "_id": "597eeb64aecdd6283a873898",
   "accessibilityOptions": [
-    "braille-menu",
-    "wheelchair-friendly"
+    "Braille",
+    "Wheelchair access"
   ],
   "categories": [
-    "restaurant",
+    "food and drink",
     "cafe"
   ]
 }
@@ -496,11 +501,11 @@ Status: 200 OK
   },
   "_id": "597eeb64aecdd6283a873898",
   "accessibilityOptions": [
-    "braille-menu",
-    "wheelchair-friendly"
+    "Braille",
+    "Wheelchair access"
   ],
   "categories": [
-    "restaurant",
+    "food and drink",
     "cafe"
   ]
 }
@@ -538,7 +543,7 @@ Status: 200 OK
     },
     "_id": "597f1b96e19cb32c342c0be0",
     "categories": [
-      "handicraft",
+      "pottery",
       "clothing"
     ]
   }
@@ -565,7 +570,7 @@ Status: 200 OK
   },
   "_id": "597f1b96e19cb32c342c0be0",
   "categories": [
-    "handicraft",
+    "pottery",
     "clothing"
   ]
 }
@@ -592,7 +597,7 @@ description* | string | Product description.
 {
   "owner": "8496873ea34958810182138c",
   "categories": [
-    "handicraft",
+    "pottery",
     "clothing"
   ],
   "imageUrl": "imgIsHere.com/12345",
@@ -621,7 +626,7 @@ Status: 201 Created
   },
   "_id": "597f1b96e19cb32c342c0be0",
   "categories": [
-    "handicraft",
+    "pottery",
     "clothing"
   ]
 }
@@ -669,7 +674,7 @@ Status: 200 OK
   },
   "_id": "597f1b96e19cb32c342c0be0",
   "categories": [
-    "handicraft",
+    "pottery",
     "clothing"
   ]
 }
@@ -858,3 +863,57 @@ Status: 200 OK
 ```
 Status: 204 No Content
 ```
+
+## Categories
+
+Below are listed the options avaliable for each of the categories across the API:
+
+### Accessibility options
+  - Audio Recordings
+  - Braille
+  - Big Fonts
+  - Carer
+  - Place for Guide Dog
+  - SMS messaging
+  - Sign Language
+  - Good Lighting
+  - Carer
+  - WheelChair Access
+  - Disabled Parking
+  - Disabled Toilets
+  - Carer
+### Place Categories
+  - cafe
+  - music venue
+  - religious site
+  - food and drink
+  - education
+  - retail
+  - sport
+  - municipal
+  - healthcare
+
+### Event Categories
+  - music
+  - dining
+  - educational
+  - conference
+  - sport
+  - competition
+  - launch
+  - party
+  - wedding
+  - cultural event
+  - miscellaneous-
+
+### Product Categories
+  - jewellery
+  - clothing
+  - crochet
+  - calligraphy
+  - embroidery
+  - metalwork
+  - food
+  - drink
+  - pottery
+  - glassware

--- a/docs.md
+++ b/docs.md
@@ -54,7 +54,7 @@ Status: 200 OK
     "__v": 0,
     "updatedAt": "2017-08-02T14:48:20.989Z",
     "createdAt": "2017-08-02T14:48:20.989Z",
-    "ownerId": "8496873ea34958810182138c",
+    "owner": "8496873ea34958810182138c",
     "place": {
       _id: '599152711fd6dc190c9940c1',
       "updatedAt": "2017-08-14T07:34:09.985Z",
@@ -99,7 +99,7 @@ Status: 200 OK
   "__v": 0,
   "updatedAt": "2017-08-02T14:48:20.989Z",
   "createdAt": "2017-08-02T14:48:20.989Z",
-  "ownerId": "8496873ea34958810182138c",
+  "owner": "8496873ea34958810182138c",
   "place": "place": {
     _id: '599152711fd6dc190c9940c1',
     "updatedAt": "2017-08-14T07:34:09.985Z",
@@ -139,7 +139,7 @@ Status: 200 OK
 
 Name | Type | Description
 ---|---|---
-ownerId | mongoose ObjectId | id of event owner.
+owner | mongoose ObjectId | id of event owner.
 categories | array of strings | **Required**. Event [categories](https://github.com/foundersandcoders/open-tourism-platform/blob/master/src/models/constants.json).
 place | mongoose ObjectId | id of event location.
 accessibilityOptions | array of strings | Event [accessibility options](https://github.com/foundersandcoders/open-tourism-platform/blob/master/src/models/constants.json).
@@ -155,7 +155,7 @@ description* | string | More information about event.
 **Sample Request**
 ```
 {
-  "ownerId": "8496873ea34958810182138c",
+  "owner": "8496873ea34958810182138c",
   "categories": [
     "music",
     "dining"
@@ -184,7 +184,7 @@ Status: 201 Created
   "__v": 0,
   "updatedAt": "2017-08-02T14:48:20.989Z",
   "createdAt": "2017-08-02T14:48:20.989Z",
-  "ownerId": "8496873ea34958810182138c",
+  "owner": "8496873ea34958810182138c",
   "place": "9348293df12398123885930a",
   "startTime": "2001-01-01T00:00:00.000Z",
   "endTime": "2002-02-02T00:00:00.000Z",
@@ -213,7 +213,7 @@ Status: 201 Created
 
 Name | Type | Description
 ---|---|---
-ownerId | mongoose ObjectId | id of event owner.
+owner | mongoose ObjectId | id of event owner.
 categories | array of strings | **Required**. Event [categories](https://github.com/foundersandcoders/open-tourism-platform/blob/master/src/models/constants.json).
 place | mongoose ObjectId | id of event location.
 accessibilityOptions | array of strings | Event [accessibility options](https://github.com/foundersandcoders/open-tourism-platform/blob/master/src/models/constants.json).
@@ -243,7 +243,7 @@ Status: 200 OK
   "__v": 0,
   "updatedAt": "2017-08-02T14:48:20.989Z",
   "createdAt": "2017-08-02T14:48:20.989Z",
-  "ownerId": "8496873ea34958810182138c",
+  "owner": "8496873ea34958810182138c",
   "place": "9348293df12398123885930a",
   "startTime": "2001-01-01T00:00:00.000Z",
   "endTime": "2002-02-02T00:00:00.000Z",
@@ -288,7 +288,7 @@ Status: 200 OK
     "__v": 0,
     "updatedAt": "2017-07-31T08:33:40.199Z",
     "createdAt": "2017-07-31T08:33:40.199Z",
-    "ownerId": "8496873ea34958810182138c",
+    "owner": "8496873ea34958810182138c",
     "location": [
       32.701358,
       32.2968133
@@ -327,7 +327,7 @@ Status: 200 OK
   "__v": 0,
   "updatedAt": "2017-07-31T08:33:40.199Z",
   "createdAt": "2017-07-31T08:33:40.199Z",
-  "ownerId": "8496873ea34958810182138c",
+  "owner": "8496873ea34958810182138c",
   "location": [
     32.701358,
     32.2968133
@@ -361,7 +361,7 @@ Status: 200 OK
 
 Name | Type | Description
 ---|---|---
-ownerId | mongoose ObjectId | id of owner in user table.
+owner | mongoose ObjectId | id of owner in user table.
 location | array of numbers | Location coordinates.
 categories | array of strings | Place [categories](https://github.com/foundersandcoders/open-tourism-platform/blob/67d654c4fbe74cdcbad5650d9d110c004673e6f2/src/models/constants.json).
 accessibilityOptions | array of strings | Place [accessibility options](https://github.com/foundersandcoders/open-tourism-platform/blob/67d654c4fbe74cdcbad5650d9d110c004673e6f2/src/models/constants.json).
@@ -379,7 +379,7 @@ openingHours* | string | Place opening hours.
 **Sample Request**
 ```
 {
-  "ownerId": "8496873ea34958810182138c",
+  "owner": "8496873ea34958810182138c",
   "location": [
     32.701358,
     32.2968133
@@ -413,7 +413,7 @@ Status: 201 Created
   "__v": 0,
   "updatedAt": "2017-07-31T08:33:40.199Z",
   "createdAt": "2017-07-31T08:33:40.199Z",
-  "ownerId": "8496873ea34958810182138c",
+  "owner": "8496873ea34958810182138c",
   "location": [
     32.701358,
     32.2968133
@@ -447,7 +447,7 @@ Status: 201 Created
 
 Name | Type | Description
 ---|---|---
-ownerId | mongoose ObjectId | id of owner in user table.
+owner | mongoose ObjectId | id of owner in user table.
 location | array of numbers | Location coordinates.
 categories | array of strings | Place [categories](https://github.com/foundersandcoders/open-tourism-platform/blob/67d654c4fbe74cdcbad5650d9d110c004673e6f2/src/models/constants.json).
 accessibilityOptions | array of strings | Place [accessibility options](https://github.com/foundersandcoders/open-tourism-platform/blob/67d654c4fbe74cdcbad5650d9d110c004673e6f2/src/models/constants.json).
@@ -479,7 +479,7 @@ Status: 200 OK
   "__v": 1,
   "updatedAt": "2017-07-31T08:33:40.199Z",
   "createdAt": "2017-07-31T08:33:40.199Z",
-  "ownerId": "8496873ea34958810182138c",
+  "owner": "8496873ea34958810182138c",
   "location": [
     32.701358,
     32.2968133
@@ -529,7 +529,7 @@ Status: 200 OK
     "__v": 0,
     "updatedAt": "2017-07-31T11:59:18.624Z",
     "createdAt": "2017-07-31T11:59:18.624Z",
-    "ownerId": "8496873ea34958810182138c",
+    "owner": "8496873ea34958810182138c",
     "imageUrl": "imgIsHere.com/12345",
     "cost": 1000,
     "en": {
@@ -556,7 +556,7 @@ Status: 200 OK
   "__v": 0,
   "updatedAt": "2017-07-31T11:59:18.624Z",
   "createdAt": "2017-07-31T11:59:18.624Z",
-  "ownerId": "8496873ea34958810182138c",
+  "owner": "8496873ea34958810182138c",
   "imageUrl": "imgIsHere.com/12345",
   "cost": 1000,
   "en": {
@@ -578,7 +578,7 @@ Status: 200 OK
 
 Name | Type | Description
 ---|---|---
-ownerId | mongoose ObjectId | id of owner in user table.
+owner | mongoose ObjectId | id of owner in user table.
 categories | array of strings | Product [categories](https://github.com/foundersandcoders/open-tourism-platform/blob/67d654c4fbe74cdcbad5650d9d110c004673e6f2/src/models/constants.json).
 imageUrl | string | Link to image of product.
 cost | number | Product cost.
@@ -590,7 +590,7 @@ description* | string | Product description.
 **Sample Request**
 ```
 {
-  "ownerId": "8496873ea34958810182138c",
+  "owner": "8496873ea34958810182138c",
   "categories": [
     "handicraft",
     "clothing"
@@ -612,7 +612,7 @@ Status: 201 Created
   "__v": 0,
   "updatedAt": "2017-07-31T11:59:18.624Z",
   "createdAt": "2017-07-31T11:59:18.624Z",
-  "ownerId": "8496873ea34958810182138c",
+  "owner": "8496873ea34958810182138c",
   "imageUrl": "imgIsHere.com/12345",
   "cost": 1000,
   "en": {
@@ -634,7 +634,7 @@ Status: 201 Created
 
 Name | Type | Description
 ---|---|---
-ownerId | mongoose ObjectId | id of owner in user table.
+owner | mongoose ObjectId | id of owner in user table.
 categories | array of strings | Product [categories](https://github.com/foundersandcoders/open-tourism-platform/blob/67d654c4fbe74cdcbad5650d9d110c004673e6f2/src/models/constants.json).
 imageUrl | string | Link to image of product.
 cost | number | Product cost.
@@ -660,7 +660,7 @@ Status: 200 OK
   "__v": 1,
   "updatedAt": "2017-07-31T11:59:18.624Z",
   "createdAt": "2017-07-31T11:59:18.624Z",
-  "ownerId": "8496873ea34958810182138c",
+  "owner": "8496873ea34958810182138c",
   "imageUrl": "imgIsHere.com/12345",
   "cost": 1000,
   "en": {

--- a/src/controllers/event.js
+++ b/src/controllers/event.js
@@ -19,7 +19,7 @@ eventController.getAll = (req, res, next) => {
   }
 
   Event.find(queries)
-    .populate('placeId')
+    .populate('place')
     .sort('startTime')
     .then(events => res.status(200).send(events))
     .catch(next)
@@ -30,7 +30,7 @@ eventController.getById = (req, res, next) => {
   // sends back one event or errors
   const id = req.params.id
   Event.findById(id)
-    .populate('placeId')
+    .populate('place')
     .then(rejectIfNull(errMessages.GET_ID_NOT_FOUND))
     .then(event => res.status(200).send(event))
     .catch(next)

--- a/src/models/Event.js
+++ b/src/models/Event.js
@@ -18,7 +18,7 @@ const eventSchema = mongoose.Schema(
     // categories can be an array of one or more strings from the enum, is required here
     categories: { type: [{ type: String, enum: eventCategories }], required: true },
     // id of place in place table
-    placeId: { type: mongoose.Schema.Types.ObjectId, ref: 'Place' },
+    place: { type: mongoose.Schema.Types.ObjectId, ref: 'Place' },
     // accessibilityOptions can be an array of one or more strings from the enum
     accessibilityOptions: { type: [{ type: String, enum: accessibilityOptions }] },
     startTime: Date,

--- a/src/models/Event.js
+++ b/src/models/Event.js
@@ -14,7 +14,7 @@ const eventTranslatedFieldsSchema = mongoose.Schema(
 const eventSchema = mongoose.Schema(
   {
     // id of owner in user table
-    ownerId: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+    owner: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
     // categories can be an array of one or more strings from the enum, is required here
     categories: { type: [{ type: String, enum: eventCategories }], required: true },
     // id of place in place table

--- a/src/models/Place.js
+++ b/src/models/Place.js
@@ -16,7 +16,7 @@ const placeTranslatedFieldsSchema = mongoose.Schema(
 const placeSchema = mongoose.Schema(
   {
     // id of owner in user table
-    ownerId: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+    owner: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
     location: { type: [Number], index: '2dsphere' },
     // categories can be an array of one or more strings from the enum, is not required here
     categories: { type: [{ type: String, enum: placeCategories }] },

--- a/src/models/Product.js
+++ b/src/models/Product.js
@@ -14,7 +14,7 @@ const productTranslatedFieldsSchema = mongoose.Schema(
 const productSchema = mongoose.Schema(
   {
     // id of owner in user table
-    ownerId: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+    owner: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
     // categories can be an array of one or more strings from the enum, is required here
     categories: { type: [{ type: String, enum: productCategories }], required: true },
     imageUrl: String,

--- a/src/models/constants.json
+++ b/src/models/constants.json
@@ -5,18 +5,18 @@
     "SUPER"
   ],
   "accessibilityOptions": [
-    "Audio Recordings",
+    "Audio recordings",
     "Braille",
-    "Big Fonts",
+    "Big fonts",
     "Carer",
-    "Place for Guide Dog",
+    "Place for guide dog",
     "SMS messaging",
-    "Sign Language",
-    "Good Lighting",
+    "Sign language",
+    "Good lighting",
     "Carer",
-    "WheelChair Access",
-    "Disabled Parking",
-    "Disabled Toilets",
+    "Wheelchair access",
+    "Disabled parking",
+    "Disabled toilets",
     "Carer"
   ],
   "placeCategories": [
@@ -40,7 +40,7 @@
     "launch",
     "party",
     "wedding",
-    "cultural event",
+    "culture",
     "miscellaneous"
   ],
   "productCategories": [

--- a/src/models/constants.json
+++ b/src/models/constants.json
@@ -1,23 +1,58 @@
 {
-   "roles":[
-      "BASIC",
-      "ADMIN",
-      "SUPER"
-   ],
-   "accessibilityOptions": [
-      "braille-menu",
-      "wheelchair-friendly"
-   ],
-   "placeCategories": [
-      "restaurant",
-      "cafe"
-   ],
-   "eventCategories": [
-      "music",
-      "dining"
-   ],
-   "productCategories": [
-      "handicraft",
-      "clothing"
-   ]
+  "roles": [
+    "BASIC",
+    "ADMIN",
+    "SUPER"
+  ],
+  "accessibilityOptions": [
+    "Audio Recordings",
+    "Braille",
+    "Big Fonts",
+    "Carer",
+    "Place for Guide Dog",
+    "SMS messaging",
+    "Sign Language",
+    "Good Lighting",
+    "Carer",
+    "WheelChair Access",
+    "Disabled Parking",
+    "Disabled Toilets",
+    "Carer"
+  ],
+  "placeCategories": [
+    "cafe",
+    "music venue",
+    "religious site",
+    "food and drink",
+    "education",
+    "retail",
+    "sport",
+    "municipal",
+    "healthcare"
+  ],
+  "eventCategories": [
+    "music",
+    "dining",
+    "educational",
+    "conference",
+    "sport",
+    "competition",
+    "launch",
+    "party",
+    "wedding",
+    "cultural event",
+    "miscellaneous"
+  ],
+  "productCategories": [
+    "jewellery",
+    "clothing",
+    "crochet",
+    "calligraphy",
+    "embroidery",
+    "metalwork",
+    "food",
+    "drink",
+    "pottery",
+    "glassware"
+  ]
 }

--- a/tests/controllers/event.test.js
+++ b/tests/controllers/event.test.js
@@ -55,7 +55,7 @@ tape('GET /events, with and without query parameters', t => {
 tape('GET /events, check place field is populated', t => {
   Place.create(validPlace1)
     .then(createdPlace => {
-      const event = Object.assign(validEvent1, { placeId: createdPlace.id })
+      const event = Object.assign(validEvent1, { place: createdPlace.id })
       return Event.create(event)
     })
     .then(createdEvent => {
@@ -65,7 +65,7 @@ tape('GET /events, check place field is populated', t => {
         .expect('Content-Type', /json/)
         .end((err, res) => {
           if (err) t.fail(err)
-          t.equal(typeof res.body[0].placeId, 'object', 'returned event should have placeId field populated')
+          t.equal(typeof res.body[0].place, 'object', 'returned event should have place field populated')
           dropCollectionsAndEnd([Place, Event], t)
         })
     })
@@ -100,7 +100,7 @@ tape('GET /events/:id with valid id of something not in the database', t => {
 tape('GET /events/:id, check place field is populated', t => {
   Place.create(validPlace1)
     .then(createdPlace => {
-      const event = Object.assign(validEvent1, { placeId: createdPlace.id })
+      const event = Object.assign(validEvent1, { place: createdPlace.id })
       return Event.create(event)
     })
     .then(createdEvent => {
@@ -111,7 +111,7 @@ tape('GET /events/:id, check place field is populated', t => {
         .end((err, res) => {
           if (err) t.fail(err)
           t.equal(res.body.en.name, validEvent1.en.name, 'should get event with correct name.')
-          t.equal(typeof res.body.placeId, 'object', 'returned event should have placeId field populated')
+          t.equal(typeof res.body.place, 'object', 'returned event should have place field populated')
           dropCollectionsAndEnd([Place, Event], t)
         })
     })
@@ -134,7 +134,7 @@ tape('POST /events adding invalid event', t => {
     })
 })
 
-tape('POST /events adding event with invalid placeId field', t => {
+tape('POST /events adding event with invalid place field', t => {
   supertest(server)
     .post('/events')
     .send(invalidEvent2)

--- a/tests/controllers/product.test.js
+++ b/tests/controllers/product.test.js
@@ -32,7 +32,7 @@ tape('GET /products, with and without query parameters', t => {
           t.ok(res.body.map(product => product.en.name).includes(validProduct2.en.name), 'second product has been added')
         })
       supertest(server)
-        .get('/products?categories=handicraft')
+        .get('/products?categories=pottery')
         .expect(200)
         .expect('Content-Type', /json/)
         .end((err, res) => {

--- a/tests/fixtures/products.json
+++ b/tests/fixtures/products.json
@@ -1,5 +1,5 @@
 {
-   "validProduct1": { "en":{"name":"hand-made mug"}, "categories":"handicraft" },
+   "validProduct1": { "en":{"name":"hand-made mug"}, "categories":"pottery" },
    "validProduct2": { "en":{"name":"small knitted scarf"}, "categories":"clothing" },
    "invalidProduct1": { "description":"super cheap sunglasses $$$" }
 }


### PR DESCRIPTION
relates #117, specifically:

- removes the appended `Id` from all `___Id` fields #96 
- adds fixed categories #82 
- Also update the docs to have categories explicitly stated

---

I got the accessibility options from v1 of easynaz, events/places from browsing the web/looking at what mohammed has begin to use in naz-events, and products from v1 of Nasijona, plus a couple of other obvious categories I thought of. Let me know if you think we should have others/lose some.

**Note:** when this gets merged to master and pushed to heroku, we will need to reset the heroku database as all the enums have changed.

So because it's mongo we need to wipe the current production database (this may have knock on effects for apps built on the platform that want to see some results, so we may want to think about adding some stuff via Postman when it is live