### PR TITLE
Tidy up security

### DIFF
--- a/src/middleware/validateJWT.js
+++ b/src/middleware/validateJWT.js
@@ -12,6 +12,7 @@ const getToken = req => {
 module.exports = opts => {
   const fixedOptions = {
     secret: process.env.JWT_SECRET,
+    credentialsRequired: false,
     getToken
   }
   const jwtOptions = Object.assign(fixedOptions, opts)

--- a/src/middleware/validateUser.js
+++ b/src/middleware/validateUser.js
@@ -15,7 +15,16 @@ const validateUserAndAddId = (req) => {
     })
 }
 
-module.exports = (req, res, next) => {
+module.exports = opts => (req, res, next) => {
+  const fixedOptions = {
+    credentialsRequired: false
+  }
+  const { credentialsRequired } = Object.assign(fixedOptions, opts)
+  if (!req.user) {
+    return credentialsRequired
+      ? next(boom.unauthorized(auth.UNAUTHORIZED))
+      : next()
+  }
   validateUserAndAddId(req)
     .then(() => next())
     .catch(next)

--- a/src/routers/apiRouter.js
+++ b/src/routers/apiRouter.js
@@ -15,7 +15,7 @@ router.route('/users')
 router.route('/users/:id')
   .get(userController.getById)
   .put(
-    validateJWT({ credentialsRequired: false }),
+    validateJWT(),
     validateHeaderToken,
     userController.update
   )

--- a/src/routers/authRouter.js
+++ b/src/routers/authRouter.js
@@ -20,10 +20,10 @@ router.route('/register')
 
 router.route('/oauth/authorize')
   .get(
-    validateJWT({ credentialsRequired: false }),
+    validateJWT(),
     oauthController.getAuthorizePage
   )
-  .post(validateJWT(), oauthController.getAuthorizationCode)
+  .post(validateJWT({ credentialsRequired: true }), oauthController.getAuthorizationCode)
 
 router.route('/oauth/token')
   .post(oauthController.getToken)
@@ -31,8 +31,8 @@ router.route('/oauth/token')
 // secure route with dummy handler for now
 router.route('/apps')
   .get(
-    validateJWT(),
-    validateUser,
+    validateJWT({ credentialsRequired: true }),
+    validateUser(),
     checkRole({ minRole: roles.SUPER }),
     appsController.get
   )


### PR DESCRIPTION
- [x] Set `credentialsRequired: false` as a default on `validateJWT` and `validateUser`
- [x] Make it so that `validateUser` won't fail with no req.user, will instead let them through (unless `credentialsRequired:true`, in which case `boom.unauthorized`)
- [x] Change when those functions are called as appropriate